### PR TITLE
Case insensitive search

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ actions: {
 If you would like to have multiple options with remote data fetching, all you need to do is to return a Promise as in single selection mode.
 
 ### <a name="search"></a>Custom search
-By default, ember-select-guru will perform searching through objects available in `options` binding by default key `searchKey` set to `name`. If your objects should be searched using different key, you can easily set it to other one:
+By default, ember-select-guru will perform case-insensitive searching through objects available in `options` binding by default key `searchKey` set to `name`. If your objects should be searched using different key, you can easily set it to other one:
 ```
 {{ember-select-guru
   value=value

--- a/addon/components/ember-select-guru.js
+++ b/addon/components/ember-select-guru.js
@@ -135,11 +135,11 @@ export default Component.extend({
     this.set('_options', possibleOptions);
   },
   _searchForOptions() {
-    const term = this.get('queryTerm');
+    const term = this.get('queryTerm').toLowerCase();
     const searchKey = this.get('searchKey');
 
     return this.get('_options').filter((item) => {
-      return (get(item, searchKey) && (get(item, searchKey).indexOf(term) > -1));
+      return (get(item, searchKey) && (get(item, searchKey).toLowerCase().indexOf(term) > -1));
     });
   }
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -49,7 +49,7 @@ export default Controller.extend({
   },
   _searchForUsers(query) {
     return this.get('names').filter((item) => {
-      return (get(item, 'name') && (get(item, 'name').indexOf(query) > -1));
+      return (get(item, 'name') && (get(item, 'name').toLowerCase().indexOf(query.toLowerCase()) > -1));
     });
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -140,7 +140,7 @@
           <h2><code>searchKey</code> property</h2>
         </div>
         <div class="col-md-4">
-          <p>You can easily change the attribute used for searching. Try typing "fifty" into the field below.</p>
+          <p><b>ember-select-guru</b> is searching through <code>name</code> property in <b>case-insensitive</b> way by default. You can easily change the attribute used for searching. Try typing "fifty" into the field below.</p>
 
           {{ember-select-guru
           value=singleValue
@@ -175,7 +175,8 @@
               options=options
               <strong>searchKey='description'</strong>
               onSelect=(action "onSelectEvent")}}
-          {{/ember-highlight-code}}
+            {{/ember-highlight-code}}
+          <p>But if you want to search in case-sensitive or any other way, check out following <b>custom search</b> section.</p>
         </div>
       </div>
       <hr>

--- a/tests/unit/ember-select-guru-test.js
+++ b/tests/unit/ember-select-guru-test.js
@@ -26,7 +26,7 @@ test('query change executes #onSearchInputChange action', function(assert) {
   assert.ok(onSearchInputChangeSpy.calledWith('New value'), '#onSearchInputChange should be executed with proper query term');
 });
 
-test('if #onSearchInputChange returns null, it sets filtered options except currently selected', function(assert) {
+test('if #onSearchInputChange returns null, it sets filtered options except currently selected case-insensitive', function(assert) {
   assert.expect(3);
 
   let component = this.subject();
@@ -42,7 +42,7 @@ test('if #onSearchInputChange returns null, it sets filtered options except curr
 
   run(() => {
     component.set('value', options[0]);
-    component.set('queryTerm', 'ABC');
+    component.set('queryTerm', 'abc');
   });
 
   assert.equal(component.get('_options.length'), 2, '_options should contain two elements');


### PR DESCRIPTION
Search in case-insensitive way by default (match defaults with select2 or ember-select-2).