### PR TITLE
add high z-index to component while its expanded

### DIFF
--- a/addon/components/ember-select-guru.js
+++ b/addon/components/ember-select-guru.js
@@ -21,6 +21,7 @@ export default Component.extend({
   multiValueComponent: 'multi-value-component',
   searchKey: 'name',
   classNames: 'ember-select-guru',
+  classNameBindings: ['isExpanded:ember-select-guru__expanded'],
   hasOptions: computed.notEmpty('_options'),
   hasValue: computed.notEmpty('value'),
   queryTermObserver: observer('queryTerm', function() {

--- a/tests/dummy/app/styles/components/_ember-select-guru.scss
+++ b/tests/dummy/app/styles/components/_ember-select-guru.scss
@@ -69,4 +69,8 @@
       background: $active;
     }
   }
+
+  &__expanded {
+    z-index: 9999;
+  }
 }

--- a/vendor/ember-select-guru.css
+++ b/vendor/ember-select-guru.css
@@ -70,6 +70,10 @@
     background: #f1efef;
 }
 
+.ember-select-guru__expanded {
+    z-index: 9999;
+}
+
 .multi-value__option {
     display: inline-block;
     margin-bottom: 3px;


### PR DESCRIPTION
Add high z-index value to component while its expanded. Without this, if one select component is under the other, the other one overlaps the first even if its expanded.